### PR TITLE
Redis Caching: Add redisKeyPrefix option

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -40,7 +40,7 @@ export class PRCClient {
     this.baseURL = options.baseURL || 'https://api.policeroleplay.community/v1';
     this.serverKey = options.serverKey;
     this.globalKey = options.globalKey;
-    this.cache = options.cache !== false ? new Cache(options.cacheMaxAge, options.redisUrl) : null;
+    this.cache = options.cache !== false ? new Cache(options.cacheMaxAge, options.redisUrl, options.redisKeyPrefix) : null;
     this.headers = this.buildHeaders();
   }
 
@@ -174,17 +174,16 @@ export class PRCClient {
   ): Promise<APIResponse<T>> {
 
     const url = `${this.baseURL}${endpoint}`;
-    const cacheKey = `${method}:${endpoint}`;
+    const cacheKey = `${endpoint}`;
     const MAX_RETRIES = 3;
 
     // Determine if caching should be used for this request
-    const shouldCache = cacheOverride !== undefined ? cacheOverride : cacheable;
+    const shouldCache = method === 'GET' && (cacheOverride !== undefined ? cacheOverride : cacheable);
 
-    if (shouldCache && method === 'GET') {
+    if (shouldCache) {
       const cachedData = await this.getCachedData<T>(cacheKey);
-      if (cachedData !== null) {
+      if (cachedData !== null) 
         return { data: cachedData };
-      }
     }
 
     let retryCount = 0;
@@ -206,9 +205,8 @@ export class PRCClient {
 
       const data = await this.parseResponseData<T>(response);
 
-      if (shouldCache && method === 'GET') {
+      if (shouldCache) 
         await this.setCachedData(cacheKey, data, cacheMaxAge);
-      }
 
       return { data };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface PRCClientOptions {
     cache?: boolean;
     cacheMaxAge?: number;
     redisUrl?: string;
+    redisKeyPrefix?: string;
 }
 
 /**


### PR DESCRIPTION
Previously, keys in a redis cache were not unique to the ER:LC server. If you used this package with multiple ER:LC servers and the same redis database they would override each other.

The fix for this is adding an option to PRCClient called redisKeyPrefix. This is a unique identifier that will be added in front of redis cache keys. e.g. where redisKeyPrefix = 1234, a key would look like  1234:/server.
This option is optional. If not provided, redis keys will have no prefix.

In addition to this fix, I removed the GET: in front of redis keys as it's unnecessary as all cachable items are GET requests.